### PR TITLE
new Init method on entities

### DIFF
--- a/example/storable.go
+++ b/example/storable.go
@@ -146,6 +146,7 @@ func (r *ProductResultSet) One() (*Product, error) {
 func (r *ProductResultSet) Next() (returned bool) {
 	r.last = nil
 	returned, r.lastErr = r.ResultSet.Next(&r.last)
+
 	return
 }
 
@@ -162,7 +163,6 @@ func (r *ProductResultSet) ForEach(f func(*Product) error) error {
 		if err != nil {
 			return err
 		}
-
 		if !found {
 			break
 		}

--- a/generator/processor_test.go
+++ b/generator/processor_test.go
@@ -17,6 +17,44 @@ type ProcessorSuite struct{}
 
 var _ = Suite(&ProcessorSuite{})
 
+func (s *ProcessorSuite) TestInit(c *C) {
+	fixtureSrc := `
+  package fixture
+
+  import  "gopkg.in/src-d/storable.v1"
+
+  type InitExample struct {
+    storable.Document
+    Foo string
+  }
+  
+  func (i *InitExample) Init() { return nil }
+  `
+
+	pkg := s.processFixture(fixtureSrc)
+	c.Assert(pkg.Models[0].Init, Equals, true)
+}
+
+func (s *ProcessorSuite) TestInitEmbedded(c *C) {
+	fixtureSrc := `
+  package fixture
+
+  import  "gopkg.in/src-d/storable.v1"
+
+  type InitEmbeddedExample struct {
+    storable.Document
+    OtherWithInit
+  }
+
+  type OtherWithInit struct {}
+
+  func (i *OtherWithInit) Init() error { return nil }
+  `
+
+	pkg := s.processFixture(fixtureSrc)
+	c.Assert(pkg.Models[0].Init, Equals, true)
+}
+
 func (s *ProcessorSuite) TestInlineStruct(c *C) {
 	fixtureSrc := `
   package fixture

--- a/generator/templates/resultset.tgo
+++ b/generator/templates/resultset.tgo
@@ -9,14 +9,33 @@ type {{.ResultSetName}} struct {
 func (r *{{.ResultSetName}}) All() ([]*{{.Name}}, error) {
     var result []*{{.Name}}
     err := r.ResultSet.All(&result)
+    {{if .Init}} \
+    if err != nil {
+	return result, err
+    }
 
-    return result, err
+    for _, r := range result {
+	if err := r.Init(); err != nil {
+	    return result, err   
+	}
+    }
+    {{end}} \
+
+
+    return result, err 
 }
 
 // One returns the first document on the resultset and close the resultset
 func (r *{{.ResultSetName}}) One() (*{{.Name}}, error) {
     var result *{{.Name}}
     err := r.ResultSet.One(&result)
+    {{if .Init}} \
+    if err != nil {
+	return result, err
+    }
+
+    err = result.Init()
+    {{end}} \
 
     return result, err
 }
@@ -25,6 +44,14 @@ func (r *{{.ResultSetName}}) One() (*{{.Name}}, error) {
 func (r *{{.ResultSetName}}) Next() (returned bool) {
     r.last = nil
     returned, r.lastErr = r.ResultSet.Next(&r.last)
+    {{if .Init}} \
+    if r.lastErr != nil {
+	return
+    }
+
+    r.lastErr = r.last.Init()
+    {{end}} \
+
     return
 }
 
@@ -41,11 +68,18 @@ func (r *{{.ResultSetName}}) ForEach(f func(*{{.Name}}) error) error {
         if err != nil {
             return err
         }
-
-        if !found {
+        
+	if !found {
             break
         }
 
+    	{{if .Init}} \
+
+	if err := result.Init(); err != nil {
+	    return err 
+        }
+	
+	{{end}} \
         err = f(result)
         if err == storable.ErrStop {
             break

--- a/generator/types.go
+++ b/generator/types.go
@@ -75,6 +75,7 @@ type Model struct {
 	Type        string
 	Fields      []*Field
 	New         bool
+	Init        bool
 	Events      Events
 	CheckedNode *types.Named
 	NewFunc     *types.Func

--- a/tests/resultset.go
+++ b/tests/resultset.go
@@ -10,3 +10,13 @@ type ResultSetFixture struct {
 func newResultSetFixture(f string) *ResultSetFixture {
 	return &ResultSetFixture{Foo: f}
 }
+
+type ResultSetInitFixture struct {
+	storable.Document `bson:",inline" collection:"resultset"`
+	Foo               string
+}
+
+func (r *ResultSetInitFixture) Init() error {
+	r.Foo = "foo"
+	return nil
+}

--- a/tests/resultset_test.go
+++ b/tests/resultset_test.go
@@ -3,8 +3,8 @@ package tests
 import (
 	"errors"
 
-	"gopkg.in/src-d/storable.v1"
 	. "gopkg.in/check.v1"
+	"gopkg.in/src-d/storable.v1"
 )
 
 func (s *MongoSuite) TestResultSetAll(c *C) {
@@ -17,6 +17,19 @@ func (s *MongoSuite) TestResultSetAll(c *C) {
 	c.Assert(docs, HasLen, 2)
 }
 
+func (s *MongoSuite) TestResultSetAllInit(c *C) {
+	store := NewResultSetInitFixtureStore(s.db)
+
+	c.Assert(store.Insert(store.New()), IsNil)
+	c.Assert(store.Insert(store.New()), IsNil)
+
+	docs, err := store.MustFind(store.Query()).All()
+	c.Assert(err, IsNil)
+	c.Assert(docs, HasLen, 2)
+	c.Assert(docs[0].Foo, Equals, "foo")
+	c.Assert(docs[1].Foo, Equals, "foo")
+}
+
 func (s *MongoSuite) TestResultSetOne(c *C) {
 	store := NewResultSetFixtureStore(s.db)
 	c.Assert(store.Insert(store.New("bar")), IsNil)
@@ -24,6 +37,19 @@ func (s *MongoSuite) TestResultSetOne(c *C) {
 	doc, err := store.MustFind(store.Query()).One()
 	c.Assert(err, IsNil)
 	c.Assert(doc.Foo, Equals, "bar")
+}
+
+func (s *MongoSuite) TestResultInitSetOne(c *C) {
+	store := NewResultSetInitFixtureStore(s.db)
+
+	a := store.New()
+	a.Foo = "qux"
+
+	c.Assert(store.Insert(a), IsNil)
+
+	doc, err := store.MustFind(store.Query()).One()
+	c.Assert(err, IsNil)
+	c.Assert(doc.Foo, Equals, "foo")
 }
 
 func (s *MongoSuite) TestResultSetNextEmpty(c *C) {
@@ -57,6 +83,19 @@ func (s *MongoSuite) TestResultSetNext(c *C) {
 	c.Assert(doc, IsNil)
 }
 
+func (s *MongoSuite) TestResultSetInitNext(c *C) {
+	store := NewResultSetInitFixtureStore(s.db)
+	c.Assert(store.Insert(store.New()), IsNil)
+
+	rs := store.MustFind(store.Query())
+	returned := rs.Next()
+	c.Assert(returned, Equals, true)
+
+	doc, err := rs.Get()
+	c.Assert(err, IsNil)
+	c.Assert(doc.Foo, Equals, "foo")
+}
+
 func (s *MongoSuite) TestResultSetForEach(c *C) {
 	store := NewResultSetFixtureStore(s.db)
 	c.Assert(store.Insert(store.New("bar")), IsNil)
@@ -64,6 +103,23 @@ func (s *MongoSuite) TestResultSetForEach(c *C) {
 
 	count := 0
 	err := store.MustFind(store.Query()).ForEach(func(*ResultSetFixture) error {
+		count++
+		return nil
+	})
+
+	c.Assert(err, IsNil)
+	c.Assert(count, Equals, 2)
+}
+
+func (s *MongoSuite) TestResultSetInitForEach(c *C) {
+	store := NewResultSetInitFixtureStore(s.db)
+	c.Assert(store.Insert(store.New()), IsNil)
+	c.Assert(store.Insert(store.New()), IsNil)
+
+	count := 0
+	err := store.MustFind(store.Query()).ForEach(func(r *ResultSetInitFixture) error {
+		c.Assert(r, NotNil)
+		c.Assert(r.Foo, Equals, "foo")
 		count++
 		return nil
 	})


### PR DESCRIPTION
Every time that a entity with the method `Init() error` is recovered from the db, the method Init is called

```go
type ResultSetInitFixture struct {
	storable.Document `bson:",inline" collection:"resultset"`
	Foo               string
}

func (r *ResultSetInitFixture) Init() error {
	r.Foo = "foo"
	return nil
}
```