### PR TITLE
Fix inline recognition

### DIFF
--- a/generator/types.go
+++ b/generator/types.go
@@ -357,13 +357,13 @@ func (f *Field) DbName() string {
 
 func (f *Field) Inline() bool {
 	tag := f.GetTagValue("bson")
-	endFieldName := strings.Index(tag, ",")
-
-	if endFieldName >= len(tag) {
-		return false
+	for _, p := range strings.Split(tag, ",") {
+		if p == "inline" {
+			return true
+		}
 	}
 
-	return tag[endFieldName+1:] == "inline"
+	return false
 }
 
 func (f *Field) ValidFields() []*Field {

--- a/generator/types_test.go
+++ b/generator/types_test.go
@@ -1,0 +1,29 @@
+package generator
+
+import (
+	"reflect"
+
+	. "gopkg.in/check.v1"
+)
+
+type TypesSuite struct{}
+
+var _ = Suite(&TypesSuite{})
+
+func (s *TypesSuite) TestFieldInline(c *C) {
+	tests := []struct {
+		tag    string
+		inline bool
+	}{
+		{"", false},
+		{`bson:"foo"`, false},
+		{`bson:"foo,inline"`, true},
+		{`bson:"foo,inline,omitempty"`, true},
+		{`bson:",inline,omitempty"`, true},
+		{`bson:",inline"`, true},
+	}
+
+	for _, t := range tests {
+		c.Assert(NewField("", "", reflect.StructTag(t.tag)).Inline(), Equals, t.inline)
+	}
+}


### PR DESCRIPTION
Right now, if the struct is like the following:

``` go
type Foo struct {
    Bar Bar `bson:",inline,omitempty"`
}
```

it's not detected, because it looked for a struct tag equal to ",inline" when in reality it can contain omitempty as well.

This PR corrects this behaviour and makes the recognition of "inline" fields work properly with all cases.
